### PR TITLE
chore(about): update job title and current focus

### DIFF
--- a/src/components/home/about.en.md
+++ b/src/components/home/about.en.md
@@ -2,9 +2,11 @@ I'm a software developer based in Valencia, Spain.
 I have a passion for building web applications, and I've been professionally doing so for more than
 15 years.
 
-I'm currently working as a Principal software engineer for Red Hat. I'm part of the team maintaining two
-great free open source projects,
-[Eclipse JKube](https://github.com/eclipse/jkube "Kubernetes Maven and Gradle plugins for Java") and 
+I'm currently working as a Senior Principal software engineer for Red Hat, where I focus on building free
+and open source tools at the intersection of Kubernetes and AI. I lead the
+[Kubernetes MCP Server](https://github.com/containers/kubernetes-mcp-server "Model Context Protocol server for Kubernetes and OpenShift"),
+a Model Context Protocol server that enables AI agents to manage Kubernetes and OpenShift clusters, and I continue to maintain
+[Eclipse JKube](https://github.com/eclipse/jkube "Kubernetes Maven and Gradle plugins for Java") and
 [Fabric8 Kubernetes Client](https://github.com/fabric8io/kubernetes-client "Kubernetes Java Client").
 
 When I'm not coding, I like to spend time with my family and friends. You may also find me running 

--- a/src/components/home/about.es.md
+++ b/src/components/home/about.es.md
@@ -2,8 +2,11 @@ Soy un desarrollador de software trabajando desde Valencia, España.
 Me apasiona construir aplicaciones web y llevo haciéndolo de forma profesional desde hace más de 15 
 años.
 
-En estos momentos estoy trabajando como Principal software developer para Red Hat.
-Formo parte del equipo encargado de mantener dos fantásticos proyectos de software libre,
+En estos momentos estoy trabajando como Senior Principal software developer para Red Hat, donde me centro
+en construir herramientas libres y de código abierto en la intersección entre Kubernetes y la IA.
+Lidero
+[Kubernetes MCP Server](https://github.com/containers/kubernetes-mcp-server "Servidor Model Context Protocol para Kubernetes y OpenShift"),
+un servidor del Model Context Protocol que permite a los agentes de IA gestionar clústeres de Kubernetes y OpenShift, y continúo manteniendo
 [Eclipse JKube](https://github.com/eclipse/jkube "Plugins Java de Maven y Gradle para Kubernetes") y
 [Fabric8 Kubernetes Client](https://github.com/fabric8io/kubernetes-client "Cliente Java para Kubernetes").
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "global.meta.description": "Marc Nuri, Senior software developer based in Valencia, Spain.",
+  "global.meta.description": "Marc Nuri, Senior Principal software engineer based in Valencia, Spain.",
   "home.title": "Marc Nuri",
   "home.subtitle": "Trying to change the world one line of code at a time",
   "home.hello": "HELLO.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,5 +1,5 @@
 {
-  "global.meta.description": "Marc Nuri, desarrollador de software senior trabajando desde Valencia, España.",
+  "global.meta.description": "Marc Nuri, Senior Principal software developer trabajando desde Valencia, España.",
   "home.title": "Marc Nuri",
   "home.subtitle": "Intentando cambiar el mundo línea de código a línea a línea de código",
   "home.hello": "HOLA.",


### PR DESCRIPTION
## Summary
- Update the about section and site meta descriptions (EN + ES) to reflect the promotion to Senior Principal Software Engineer at Red Hat.
- Introduce the Kubernetes MCP Server as the current lead project.
- Continue to list Eclipse JKube and Fabric8 Kubernetes Client as ongoing work.